### PR TITLE
Fix schedule sleep and add request timeout

### DIFF
--- a/OF.py
+++ b/OF.py
@@ -82,7 +82,12 @@ def publish_to_hashnode(title, content):
         }
     }
     try:
-        response = requests.post(HASHNODE_API_URL, headers=headers, json=payload)
+        response = requests.post(
+            HASHNODE_API_URL,
+            headers=headers,
+            json=payload,
+            timeout=10,
+        )
         if response.status_code != 200:
             print("Hashnode response error:", response.text)
         response.raise_for_status()
@@ -113,6 +118,6 @@ schedule.every(30).seconds.do(run_automation)
 print("Automation script is running...")
 while True:
     schedule.run_pending()
-    time.sleep(60)
+    time.sleep(30)
 
 # --- End Revised Code ---


### PR DESCRIPTION
## Summary
- keep schedule loop consistent by sleeping for 30 seconds
- set a 10‑second timeout on the Hashnode request

## Testing
- `python -m py_compile OF.py`


------
https://chatgpt.com/codex/tasks/task_e_684bb465d31c8332a0613f25749926d7